### PR TITLE
Aliases support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
        matrix:
-         python-version: [3.7, 3.8, 3.9]
+         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,6 @@
 name: Tests
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,4 @@
 !*.yml
 
 # Unignore tests configuration
-!test_objects_modules_aliases.json
 !tests/test_modules_aliases.json

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 !*.pyi
 !*.toml
 !*.yml
+
+# Unignore tests configuration
+!tests/test_modules_aliases.json

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@
 !*.yml
 
 # Unignore tests configuration
+!test_objects_modules_aliases.json
 !tests/test_modules_aliases.json

--- a/make_stubs.py
+++ b/make_stubs.py
@@ -16,10 +16,10 @@ def main():
     parser.add_argument('--output-dir', type=os.path.abspath, required=True)
     parser.add_argument(
         '--described-objects', type=os.path.abspath, required=False,
-        help='A dictionary from python objects to tuples consisting of module and qualname for each object (e.g. '
-             "ModuleType: (types, ModuleType). Such objects' names and modules will not be deduced based on runtime "
-             'data and provided names and modules will be used instead. Provided python file must have '
-             'DESCRIBED_OBJECTS dictionary on the module level.'
+        help='A path to a python file containing a dictionary from python objects to tuples consisting of module and '
+             'qualname for each object (e.g. ModuleType: ("types", "ModuleType")). Such objects\' names and modules '
+             'will not be deduced based on runtime data and provided names and modules will be used instead. Provided '
+             'python file must have DESCRIBED_OBJECTS dictionary on the module level.'
     )
     parser.add_argument(
         '--modules-aliases', type=os.path.abspath, required=False,
@@ -33,10 +33,10 @@ def main():
 
     if args.described_objects:
         spec = importlib.util.spec_from_file_location(
-            "described_objects", os.path.join(os.getcwd(), args.described_objects)
+            'described_objects', os.path.join(os.getcwd(), args.described_objects)
         )
         described_objects = importlib.util.module_from_spec(spec)
-        sys.modules["described_objects"] = described_objects
+        sys.modules['described_objects'] = described_objects
         spec.loader.exec_module(described_objects)
         described_objects = getattr(described_objects, 'DESCRIBED_OBJECTS', None)
         if described_objects is None:

--- a/make_stubs.py
+++ b/make_stubs.py
@@ -1,5 +1,7 @@
+import importlib.util
 import os
 import json
+import sys
 from argparse import ArgumentParser
 
 from stubmaker.builder.representations_tree_builder import RepresentationsTreeBuilder
@@ -13,6 +15,12 @@ def main():
     parser.add_argument('--src-root', type=os.path.abspath, required=True, help='Path to source files to process')
     parser.add_argument('--output-dir', type=os.path.abspath, required=True)
     parser.add_argument(
+        '--objects-aliases', type=os.path.abspath, required=False,
+        help='A dictionary from python objects to fullnames (in <module_path>.<object_name> format). Such objects '
+             'names and modules will not be deduced based on runtime data and provided names and modules will be used '
+             'instead. Provided python file must have OBJECTS_ALIASES dictionary on module level.'
+    )
+    parser.add_argument(
         '--modules-aliases', type=os.path.abspath, required=False,
         help='Path to module names to aliases mapping in json format.'
     )
@@ -21,6 +29,17 @@ def main():
     # Making sure our module is imported from provided src-root even
     # another version of the module is installed in the system
     override_module_import_path(args.module_root, args.src_root)
+
+    if args.objects_aliases:
+        spec = importlib.util.spec_from_file_location(
+            "objects_aliases", os.path.join(os.getcwd(), args.objects_aliases)
+        )
+        objects_aliases = importlib.util.module_from_spec(spec)
+        sys.modules["objects_aliases"] = objects_aliases
+        spec.loader.exec_module(objects_aliases)
+        objects_aliases = getattr(objects_aliases, 'OBJECTS_ALIASES', None)
+        if objects_aliases is None:
+            raise RuntimeError('OBJECT_ALIASES dict should be defined in objects-modules-aliases py file')
 
     if args.modules_aliases:
         with open(args.modules_aliases) as f:
@@ -42,7 +61,11 @@ def main():
         print(f'{module_name} -> {dst_path}')
         with open(dst_path, 'w') as stub_flo:
             builder = RepresentationsTreeBuilder(
-                module_name, module, args.module_root, args.modules_aliases and modules_aliases_mapping
+                module_name=module_name,
+                module=module,
+                module_root=args.module_root,
+                described_objects=args.objects_aliases and objects_aliases,
+                modules_aliases_mapping=args.modules_aliases and modules_aliases_mapping
             )
 
             viewer = StubViewer()

--- a/src/builder/common.py
+++ b/src/builder/common.py
@@ -1,5 +1,4 @@
 import inspect
-from functools import cached_property
 from typing import Optional, get_type_hints, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -81,7 +80,7 @@ class BaseDefinition(BaseRepresentation):
             obj=getattr(self.obj, member_name),
         )
 
-    @cached_property
+    @property
     def docstring(self) -> Optional['BaseDefinition']:
         if getattr(self.obj, '__doc__') is not None:
             return self.tree.get_documentation_definition(self.get_node_for_member('__doc__'))

--- a/src/builder/common.py
+++ b/src/builder/common.py
@@ -1,6 +1,9 @@
 import inspect
 from functools import cached_property
-from typing import Optional, get_type_hints
+from typing import Optional, get_type_hints, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stubmaker.builder.representations_tree_builder import RepresentationsTreeBuilder
 
 
 class Node:

--- a/src/builder/definitions/attribute_annotation_def.py
+++ b/src/builder/definitions/attribute_annotation_def.py
@@ -8,7 +8,7 @@ class AttributeAnnotationDef(BaseDefinition):
         super().__init__(node, tree)
         # we don't want to associate annotation object with name (e.g. TypeVar used in annotation shouldn't be accessed
         # with this name)
-        self.annotation = self.tree.get_literal(Node(node.namespace, '', node.obj))
+        self.annotation = self.tree.get_literal(self.tree.create_node_for_object(node.namespace, '', node.obj))
 
     @property
     def id(self):

--- a/src/builder/definitions/enum_def.py
+++ b/src/builder/definitions/enum_def.py
@@ -8,6 +8,9 @@ class EnumDef(BaseDefinition):
     def __init__(self, node: Node, tree: BaseRepresentationsTreeBuilder):
         super().__init__(node, tree)
         assert issubclass(node.obj, Enum)
-        self.docstring = self.tree.get_docstring(self.node)
-        self.bases = [self.tree.get_literal(Node(self.namespace, None, base)) for base in self.obj.__bases__]
-        self.enum_dict = {e.name: tree.get_literal(Node(self.namespace, None, e.value)) for e in self.obj}
+        self.bases = [self.tree.get_literal(
+            self.tree.create_node_for_object(self.namespace, None, base)
+        ) for base in self.obj.__bases__]
+        self.enum_dict = {
+            e.name: tree.get_literal(self.tree.create_node_for_object(self.namespace, None, e.value)) for e in self.obj
+        }

--- a/src/builder/definitions/function_def.py
+++ b/src/builder/definitions/function_def.py
@@ -22,18 +22,21 @@ class FunctionDef(BaseDefinition):
         for param in signature.parameters.values():
             if param.annotation is not inspect.Parameter.empty:
                 annotation = param.annotation if tree.preserve_forward_references else annotations[param.name]
-                param = param.replace(annotation=tree.get_literal(Node(self.namespace, None, annotation)))
+                param = param.replace(
+                    annotation=tree.get_literal(self.tree.create_node_for_object(self.namespace, None, annotation))
+                )
             if param.default is not inspect.Parameter.empty:
-                param = param.replace(default=tree.get_literal(Node(self.namespace, None, param.default)))
+                param = param.replace(
+                    default=tree.get_literal(self.tree.create_node_for_object(self.namespace, None, param.default))
+                )
             params.append(param)
 
         return_annotation = signature.return_annotation
         if return_annotation is not inspect.Parameter.empty:
             annotation = return_annotation if tree.preserve_forward_references else annotations['return']
-            return_annotation = tree.get_literal(Node(self.namespace, None, annotation))
+            return_annotation = tree.get_literal(self.tree.create_node_for_object(self.namespace, None, annotation))
 
         self.signature = signature.replace(parameters=params, return_annotation=return_annotation)
-        self.docstring = tree.get_docstring(node)
 
     def get_parameter(self, arg_name: str) -> inspect.Parameter:
         return self.signature.parameters.get(arg_name)

--- a/src/builder/definitions/module_def.py
+++ b/src/builder/definitions/module_def.py
@@ -1,8 +1,7 @@
 import builtins
 import inspect
 from collections import defaultdict
-from collections.abc import Iterable
-from typing import Any, Dict, Set, Tuple, Optional, Callable, TypeVar
+from typing import Any, Dict, Set, Tuple, Optional, Callable, TypeVar, Iterable
 
 from stubmaker.builder.common import (
     Node,

--- a/src/builder/import_.py
+++ b/src/builder/import_.py
@@ -4,9 +4,8 @@ import sys
 from importlib import import_module
 from importlib.abc import MetaPathFinder
 from importlib.machinery import ModuleSpec
-from importlib.util import find_spec, resolve_name, spec_from_file_location
+from importlib.util import resolve_name, spec_from_file_location
 from pkgutil import walk_packages
-from typing import Optional, Tuple
 
 from _frozen_importlib_external import _NamespaceLoader
 

--- a/src/builder/import_.py
+++ b/src/builder/import_.py
@@ -73,29 +73,3 @@ def traverse_modules(module_root, sources_path, skip_modules=None):
             logging.info(f'Skipping module {module_name}')
         else:
             yield module_name, import_module(module_name)
-
-
-def split_qulaname(qualname) -> Tuple[str, Optional[str]]:
-    """
-    Splits a qualname into a module_name and a nested_name
-    Args:
-        qualname: a __qualname__ of an object
-
-    Returns: A tuple of module_name and a nested_name where
-        * module_name is the largest subqualname that resolves to a module
-        * nested_name is the rest of the qualname or None if module_name is qualname
-    """
-
-    module_name = qualname
-    while module_name:
-        try:
-            find_spec(module_name)
-        except ImportError:
-            module_name = module_name[:module_name.rfind('.')]
-        else:
-            break
-
-    if not module_name:
-        raise ValueError(f'Qualname {qualname:}')
-
-    return module_name, qualname[len(module_name) + 1:] or None

--- a/src/builder/literals/enum_value_literal.py
+++ b/src/builder/literals/enum_value_literal.py
@@ -5,4 +5,6 @@ class EnumValueLiteral(BaseLiteral):
 
     def __init__(self, node: Node, tree: BaseRepresentationsTreeBuilder):
         super().__init__(node, tree)
-        self.enum_class = self.tree.get_literal(Node(self.namespace, None, self.obj.__objclass__))
+        self.enum_class = self.tree.get_literal(
+            self.tree.create_node_for_object(self.namespace, None, self.obj.__objclass__)
+        )

--- a/src/builder/literals/type_hint_literal.py
+++ b/src/builder/literals/type_hint_literal.py
@@ -2,6 +2,7 @@ import sys
 import typing
 from typing import Union, Optional, Callable
 
+import typing_inspect
 from stubmaker.builder.common import BaseLiteral, BaseRepresentationsTreeBuilder, Node
 
 
@@ -33,11 +34,15 @@ class TypeHintLiteral(BaseLiteral):
             origin = getattr(self.obj, '__origin__', self.obj)
 
         if origin is Callable and len(args) > 0 and args[0] is not Ellipsis:
-            args = ([self.tree.get_literal(Node(self.namespace, None, arg)) for arg in args[:-1]], args[-1])
+            args = ([self.tree.get_literal(self.tree.create_node_for_object(self.namespace, None, arg))
+                     for arg in args[:-1]], args[-1])
         elif origin is Union and type(None) in args and len(args) == 2:  # noqa: E721
             origin = Optional
             args = [arg for arg in args if arg is not type(None)]  # noqa: E721
 
         args = [None if arg is type(None) else arg for arg in args]  # noqa: E721
-        self.type_hint_origin = self.tree.get_literal_for_reference(Node(self.namespace, None, origin))
-        self.type_hint_args = [self.tree.get_literal(Node(self.namespace, None, arg)) for arg in args]
+        self.type_hint_origin = self.tree.get_literal_for_reference(
+            self.tree.create_node_for_object(self.namespace, None, origin)
+        )
+        self.type_hint_args = [self.tree.get_literal(self.tree.create_node_for_object(self.namespace, None, arg))
+                               for arg in args]

--- a/src/builder/literals/type_hint_literal.py
+++ b/src/builder/literals/type_hint_literal.py
@@ -2,7 +2,6 @@ import sys
 import typing
 from typing import Union, Optional, Callable
 
-import typing_inspect
 from stubmaker.builder.common import BaseLiteral, BaseRepresentationsTreeBuilder, Node
 
 

--- a/src/builder/literals/type_var_literal.py
+++ b/src/builder/literals/type_var_literal.py
@@ -8,8 +8,17 @@ class TypeVarLiteral(BaseLiteral):
 
     def __init__(self, node: Node, tree: BaseRepresentationsTreeBuilder):
         super().__init__(node, tree)
-        self.type_var_name = self.tree.get_literal(Node(self.namespace, None, self.obj.__name__))
-        self.type_var_reference = self.tree.get_literal(Node(self.namespace, None, TypeVar))
-        self.covariant = self.tree.get_literal(Node(self.namespace, None, self.obj.__covariant__))
-        self.contravariant = self.tree.get_literal(Node(self.namespace, None, self.obj.__contravariant__))
-        self.bound = self.tree.get_literal(Node(self.namespace, None, self.obj.__bound__))
+        self.origin = self.tree.get_literal(self.tree.create_node_for_object(self.namespace, None, TypeVar))
+        self.type_var_name = self.tree.get_literal(
+            self.tree.create_node_for_object(self.namespace, None, self.obj.__name__)
+        )
+        self.type_var_reference = self.tree.get_literal(self.tree.create_node_for_object(self.namespace, None, TypeVar))
+        self.covariant = self.tree.get_literal(
+            self.tree.create_node_for_object(self.namespace, None, self.obj.__covariant__)
+        )
+        self.contravariant = self.tree.get_literal(
+            self.tree.create_node_for_object(self.namespace, None, self.obj.__contravariant__)
+        )
+        self.bound = self.tree.get_literal(
+            self.tree.create_node_for_object(self.namespace, None, self.obj.__bound__)
+        )

--- a/src/builder/representations_tree_builder.py
+++ b/src/builder/representations_tree_builder.py
@@ -25,6 +25,11 @@ from typing_inspect import is_generic_type
 
 class RepresentationsTreeBuilder(BaseRepresentationsTreeBuilder):
 
+    DEFAULT_DESCRIBED_OBJECTS = {
+        ModuleType: ('types', 'ModuleType'),
+        ContextVar: ('contextvars', 'ContextVar'),
+    }
+
     def __init__(
         self,
         module_name, module,
@@ -40,9 +45,9 @@ class RepresentationsTreeBuilder(BaseRepresentationsTreeBuilder):
             module: current module object.
             module_root: current module root package. Used in imports.
             modules_aliases_mapping: a dictionary of modules aliases to use.
-            objects_with_redefined_modules: a dictionary from python objects to fullnames (in
-                <module_path>.<qualname> format). Such objects' names and modules will not be deduced based on
-                runtime data and provided names and modules will be used instead.
+            described_objects: a dictionary from python objects to tuples consisting of module and qualname for each
+                object (e.g. ModuleType: ("types", "ModuleType")). Such objects' names and modules will not be deduced
+                based on runtime data and provided names and modules will be used instead.
             preserve_forward_references: if True forward references will not be evaluated in resulting expressions.
         """
 
@@ -53,20 +58,9 @@ class RepresentationsTreeBuilder(BaseRepresentationsTreeBuilder):
                 '_asyncio': 'asyncio',
             }
 
-        if described_objects is None:
-            self.object_qualname_mapping = {
-                ModuleType: 'ModuleType',
-                ContextVar: 'ContextVar',
-            }
-            self.object_module_mapping = {
-                ModuleType: 'types',
-                ContextVar: 'contextvars',
-            }
-        else:
-            self.object_qualname_mapping = {obj: qualname for obj, (_, qualname) in
-                                            described_objects.items()}
-            self.object_module_mapping = {obj: module for obj, (module, _) in
-                                          described_objects.items()}
+        described_objects = described_objects or self.DEFAULT_DESCRIBED_OBJECTS
+        self.object_qualname_mapping = {obj: qualname for obj, (_, qualname) in described_objects.items()}
+        self.object_module_mapping = {obj: module for obj, (module, _) in described_objects.items()}
 
         self.module_name = module_name
         self.module_root = module_root or module_name

--- a/src/builder/representations_tree_builder.py
+++ b/src/builder/representations_tree_builder.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import enum
 import inspect
 from contextvars import ContextVar
@@ -76,7 +76,7 @@ class RepresentationsTreeBuilder(BaseRepresentationsTreeBuilder):
         self.module_rep = self.get_module_definition(self.create_node_for_object('', '', module))
 
     def create_node_for_object(self, namespace, name, obj):
-        if isinstance(obj, collections.Hashable):
+        if isinstance(obj, collections.abc.Hashable):
             module_name = self.object_module_mapping.get(obj)
             qualname = self.object_qualname_mapping.get(obj)
         else:

--- a/src/viewers/basic_viewer.py
+++ b/src/viewers/basic_viewer.py
@@ -11,6 +11,7 @@ from stubmaker.builder.definitions import (
     AttributeAnnotationDef,
     AttributeDef,
     BaseClassDef,
+    ClassDef,
     MetaclassDef,
     DocumentationDef,
     EnumDef,

--- a/src/viewers/basic_viewer.py
+++ b/src/viewers/basic_viewer.py
@@ -4,9 +4,9 @@ __all__ = [
 
 import enum
 import inspect
-from typing import ForwardRef, TypeVar
+from typing import ForwardRef
 
-from stubmaker.builder.common import BaseRepresentation, Node, BaseDefinition
+from stubmaker.builder.common import BaseRepresentation, BaseDefinition
 from stubmaker.builder.definitions import (
     AttributeAnnotationDef,
     AttributeDef,

--- a/src/viewers/basic_viewer.py
+++ b/src/viewers/basic_viewer.py
@@ -10,7 +10,7 @@ from stubmaker.builder.common import BaseRepresentation, BaseDefinition
 from stubmaker.builder.definitions import (
     AttributeAnnotationDef,
     AttributeDef,
-    ClassDef,
+    BaseClassDef,
     MetaclassDef,
     DocumentationDef,
     EnumDef,
@@ -41,7 +41,7 @@ class BasicViewer(ViewerBase):
     def view_attribute_definition(self, attribute_def: AttributeDef):
         raise NotImplementedError
 
-    def view_class_definition(self, class_def: ClassDef):
+    def view_base_class_definition(self, class_def: BaseClassDef):
         raise NotImplementedError
 
     def view_documentation_definition(self, documentation_def: DocumentationDef):

--- a/src/viewers/basic_viewer.py
+++ b/src/viewers/basic_viewer.py
@@ -58,10 +58,9 @@ class BasicViewer(ViewerBase):
 
     def view_reference_literal(self, reference_lit: ReferenceLiteral):
         if inspect.isclass(reference_lit.obj) or inspect.isfunction(reference_lit.obj):
-            qualname = reference_lit.obj.__qualname__
+            qualname = reference_lit.qualname
             prefix = get_common_namespace_prefix(reference_lit.namespace, qualname[:qualname.rfind('.')])
             return qualname[len(prefix):]
-
         return getattr(reference_lit.obj, '__name__', None) or reference_lit.obj._name
 
     def view_type_hint_literal(self, type_hint_lit: TypeHintLiteral):
@@ -155,7 +154,7 @@ class BasicViewer(ViewerBase):
         yield from type_hint_lit.type_hint_args
 
     def iter_over_type_var_literal(self, type_var_lit: TypeVarLiteral):
-        yield type_var_lit.tree.get_literal(Node(type_var_lit.namespace, None, TypeVar))
+        yield type_var_lit.origin
         yield type_var_lit.type_var_name
         yield type_var_lit.covariant
         yield type_var_lit.contravariant

--- a/tests/expected_stubs/__init__.pyi
+++ b/tests/expected_stubs/__init__.pyi
@@ -9,6 +9,7 @@ __all__ = [
     'module',
     'classes',
     'external_typevar',
+    'ClassWithRedefinedModule',
 ]
 import typing
 
@@ -25,3 +26,6 @@ def get_implicit_annotation(): ...
 
 
 external_typevar = typing.TypeVar('external_typevar')
+
+class ClassWithRedefinedModule:
+    ...

--- a/tests/expected_stubs/hidden_module.pyi
+++ b/tests/expected_stubs/hidden_module.pyi
@@ -5,5 +5,4 @@ This module is supposed to be used via hidden_module_proxy.py in stubs
 __all__ = [
     'HiddenClass',
 ]
-class HiddenClass:
-    ...
+from test_package.hidden_module_proxy import HiddenClass

--- a/tests/expected_stubs/hidden_module_proxy.pyi
+++ b/tests/expected_stubs/hidden_module_proxy.pyi
@@ -4,4 +4,5 @@
 __all__ = [
     'HiddenClass',
 ]
-from test_package.hidden_module_proxy import HiddenClass
+class HiddenClass:
+    ...

--- a/tests/expected_stubs/imports.pyi
+++ b/tests/expected_stubs/imports.pyi
@@ -8,10 +8,16 @@ __all__ = [
     'Path',
     'join',
     'splitext',
+    'attribute_of_type_with_redefined_module_1',
+    'attribute_of_type_with_redefined_module_2',
+    'attribute_of_type_with_redefined_module_3',
 ]
+import contextvars
 import pathlib
+import test_package
 import test_package.classes
 import test_package.docstrings
+import types
 
 from pathlib import Path
 from posixpath import (
@@ -33,3 +39,10 @@ class UsedByUsedInAllClass(test_package.docstrings.SimpleClass):
 
 class UsedInAllClass(UsedByUsedInAllClass):
     ...
+
+
+attribute_of_type_with_redefined_module_1: types.ModuleType
+
+attribute_of_type_with_redefined_module_2: test_package.ClassWithRedefinedModule
+
+attribute_of_type_with_redefined_module_3: contextvars.ContextVar

--- a/tests/test_described_objects.py
+++ b/tests/test_described_objects.py
@@ -1,0 +1,9 @@
+from contextvars import ContextVar
+from types import ModuleType
+from test_package import ClassWithRedefinedModule
+
+DESCRIBED_OBJECTS = {
+    ModuleType: ('types', 'ModuleType'),
+    ClassWithRedefinedModule: ('test_package', 'ClassWithRedefinedModule'),
+    ContextVar: ('contextvars', 'ContextVar'),
+}

--- a/tests/test_modules_aliases.json
+++ b/tests/test_modules_aliases.json
@@ -1,0 +1,3 @@
+{
+    "test_package.hidden_module": "test_package.hidden_module_proxy"
+}

--- a/tests/test_objects_aliases.py
+++ b/tests/test_objects_aliases.py
@@ -1,9 +1,0 @@
-from contextvars import ContextVar
-from types import ModuleType
-from test_package import ClassWithRedefinedModule
-
-OBJECTS_ALIASES = {
-    ModuleType: ['types', 'ModuleType'],
-    ClassWithRedefinedModule: ['test_package', 'ClassWithRedefinedModule'],
-    ContextVar: ['contextvars', 'ContextVar']
-}

--- a/tests/test_objects_aliases.py
+++ b/tests/test_objects_aliases.py
@@ -1,0 +1,9 @@
+from contextvars import ContextVar
+from types import ModuleType
+from test_package import ClassWithRedefinedModule
+
+OBJECTS_ALIASES = {
+    ModuleType: ['types', 'ModuleType'],
+    ClassWithRedefinedModule: ['test_package', 'ClassWithRedefinedModule'],
+    ContextVar: ['contextvars', 'ContextVar']
+}

--- a/tests/test_package/__init__.py
+++ b/tests/test_package/__init__.py
@@ -7,7 +7,8 @@ __all__ = [
     'SubpackageClass',
     'module',
     'classes',
-    'external_typevar'
+    'external_typevar',
+    'ClassWithRedefinedModule',
 ]
 import typing
 
@@ -31,3 +32,7 @@ def get_implicit_annotation():
 
 
 external_typevar = typing.TypeVar('external_typevar')
+
+
+class ClassWithRedefinedModule:
+    __module__ = 'fake'

--- a/tests/test_package/imports.py
+++ b/tests/test_package/imports.py
@@ -7,16 +7,21 @@ __all__ = [
     'Path',
     'join',
     'splitext',
+    'attribute_of_type_with_redefined_module_1',
+    'attribute_of_type_with_redefined_module_2',
+    'attribute_of_type_with_redefined_module_3',
 ]
 # Many imports below are useless for stubs. Stub generation should provide only necessary imports for the stub file.
 import os
 import typing
+from contextvars import ContextVar
 
 from pathlib import Path
 from functools import *
+from types import ModuleType
 
 from .classes import SimpleClass, InheritedClass
-from . import docstrings
+from . import docstrings, ClassWithRedefinedModule
 from .docstrings import module_function
 from .enums import *
 # check "from ... import (...)" form of import in stubs
@@ -49,3 +54,8 @@ class UsedByUsedInAllClass(docstrings.SimpleClass):
 
 class UsedInAllClass(UsedByUsedInAllClass):
     pass
+
+
+attribute_of_type_with_redefined_module_1: ModuleType
+attribute_of_type_with_redefined_module_2: ClassWithRedefinedModule
+attribute_of_type_with_redefined_module_3: ContextVar

--- a/tests/test_stubmaker.py
+++ b/tests/test_stubmaker.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 import pytest
 import subprocess
@@ -28,6 +27,7 @@ def get_output_path(tmpdir_factory):
             '--module-root', 'test_package',
             '--src-root', get_input_path(),
             '--output-dir', output_path,
+            '--objects-aliases', os.path.join(TEST_DIR, 'test_objects_aliases.py'),
             '--modules-aliases', os.path.join(TEST_DIR, 'test_modules_aliases.json'),
         ],
         stderr=subprocess.PIPE, text=True,

--- a/tests/test_stubmaker.py
+++ b/tests/test_stubmaker.py
@@ -27,7 +27,7 @@ def get_output_path(tmpdir_factory):
             '--module-root', 'test_package',
             '--src-root', get_input_path(),
             '--output-dir', output_path,
-            '--objects-aliases', os.path.join(TEST_DIR, 'test_objects_aliases.py'),
+            '--described-objects', os.path.join(TEST_DIR, 'test_described_objects.py'),
             '--modules-aliases', os.path.join(TEST_DIR, 'test_modules_aliases.json'),
         ],
         stderr=subprocess.PIPE, text=True,

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ requires = setuptools >= 36.2.0
 
 [gh-actions]
 python =
+    3.7: py37
     3.8: py38
     3.9: py39
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.3.0
-envlist = py38, py39
+envlist = py37, py38, py39, py310
 isolated_build = True
 requires = setuptools >= 36.2.0
 
@@ -9,6 +9,7 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,11 @@ deps =
     pytest
     docstring_parser
     mypy
+    flake8
 commands =
     pytest
     mypy tests/expected_stubs
+    flake8 --select=E,W,F --ignore=E122,E123,E127,E131,E203,E225,E226,E24,E275,E305,E306,E402,E722,E731,E741,F722,W503,W504,C9,N8 --max-line-length=200 src
 
 [testenv:release]
 basepython = python3.8


### PR DESCRIPTION
Added support for objects' module and qualname aliases.

Examples when this feature is required:
* `pandas.DataFrame.__module__` is `pandas.core.frame`. It is possible to import `DataFrame` from `pandas.core.frame` instead of `pandas` but undesired
* `types.ModuleType.__module__` is `builtins` and `types.ModuleType.__qualname__` is `module`. Attempt to import `module` from `builtins` leads to ImportError.

The feature is implemented by passing a python module path as an argument. This module should define `DESCRIBED_OBJECTS` dictionary at the top level, which is a mapping from python objects to tuples consisting of module name and qualname for the described object.