### PR TITLE
Make used_object_ids discovery recursive

### DIFF
--- a/tests/expected_stubs/imports.pyi
+++ b/tests/expected_stubs/imports.pyi
@@ -33,11 +33,19 @@ class SomeChild(test_package.classes.InheritedClass):
     class_attribute: test_package.classes.SomeType
 
 
-class UsedByUsedInAllClass(test_package.docstrings.SimpleClass):
+class Base1(test_package.docstrings.SimpleClass):
     ...
 
 
-class UsedInAllClass(UsedByUsedInAllClass):
+class Base2(Base1):
+    ...
+
+
+class Base3(Base2):
+    ...
+
+
+class UsedInAllClass(Base3):
     ...
 
 

--- a/tests/test_package/imports.py
+++ b/tests/test_package/imports.py
@@ -48,11 +48,19 @@ class NotUsedInAllClass:
 
 
 # should appear in stubs. also should cause docstrings module import
-class UsedByUsedInAllClass(docstrings.SimpleClass):
+class Base1(docstrings.SimpleClass):
     pass
 
 
-class UsedInAllClass(UsedByUsedInAllClass):
+class Base2(Base1):
+    pass
+
+
+class Base3(Base2):
+    pass
+
+
+class UsedInAllClass(Base3):
     pass
 
 


### PR DESCRIPTION
The depth of used object ids discovery is currently limited, which leads to incorrect stubs